### PR TITLE
Set camp-index fatalsToBrowser

### DIFF
--- a/cgi-bin/camp-index
+++ b/cgi-bin/camp-index
@@ -4,6 +4,7 @@ use warnings;
 use strict;
 use lib '/home/camp/lib';
 use Camp::Master qw(camp_list);
+use CGI::Carp qw(fatalsToBrowser);
 
 my $title = 'Your camps here';
 my $camp_type = 'sample';


### PR DESCRIPTION
Many errors that occur in the underlying Camp::Master result in die(). Having those reflect back out to the browser saves consider debugging effort, and the page is always used for internal consumption only.
